### PR TITLE
aldonu informon pri mapCopyright kaj aliaj meta-informojn

### DIFF
--- a/main.json
+++ b/main.json
@@ -201,6 +201,21 @@
          "name":"mapCopyright",
          "type":"string",
          "value":"CC BY-SA 4.0 C3Esperanto \u2605 \u0124aoso Internacia"
+        }, 
+        {
+         "name":"mapDescription",
+         "type":"string",
+         "value":"Esperanto \u2014 die internationale Sprache \u2014 the international language \u2014 la lingvo internacia"
+        }, 
+        {
+         "name":"mapLink",
+         "type":"string",
+         "value":"https:\/\/github.com\/c3esperanto\/r3c-Esperanto_asembleo"
+        }, 
+        {
+         "name":"mapName",
+         "type":"string",
+         "value":"Esperanto \u2605 \u0124aoso Internacia"
         }],
  "renderorder":"right-down",
  "tiledversion":"1.7.2",

--- a/main.json
+++ b/main.json
@@ -196,6 +196,12 @@
  "nextlayerid":17,
  "nextobjectid":1,
  "orientation":"orthogonal",
+ "properties":[
+        {
+         "name":"mapCopyright",
+         "type":"string",
+         "value":"CC BY-SA 4.0 C3Esperanto \u2605 \u0124aoso Internacia"
+        }],
  "renderorder":"right-down",
  "tiledversion":"1.7.2",
  "tileheight":32,


### PR DESCRIPTION
`mapCopyright`="CC BY-SA 4.0 C3Esperanto ★ Ĥaoso Internacia"

`mapName`="Esperanto ★ Ĥaoso Internacia"
`mapDescription`="Esperanto — die internationale Sprache — the international language — la lingvo internacia"
`mapLink`="https://github.com/c3esperanto/r3c-Esperanto_asembleo"