### PR TITLE
ligu al https://c3eo.chaotik.de en `mapLink`

### DIFF
--- a/main.json
+++ b/main.json
@@ -210,7 +210,7 @@
         {
          "name":"mapLink",
          "type":"string",
-         "value":"https:\/\/github.com\/c3esperanto\/r3c-Esperanto_asembleo"
+         "value":"https:\/\/c3eo.chaotik.de"
         }, 
         {
          "name":"mapName",


### PR DESCRIPTION
ĉar tio estas la retpaĝo pri la grupo

> Auf was soll man das vom Linter empfohlene Karten-Custom-Property `mapLink` eigentlich setzen? URL zum Repo? Website der Assembly?

— @das-g [en #rc3-world](https://matrix.to/#/!XxOXzjHtyrYRfFPsjx:hackint.org/$tAYARd2sqmZsyuaxZoUbTcW0ZMMF1UtwNoR2lPgYZF8?via=hackint.org&via=matrix.org)

> auf einen link mit weiteren infos zu deinem assembly/projekt/deiner gruppe — der link steht dann in den map infos (knopf an der seite) und wird dort besucher\*innen angezeigt

— s​tuebinm [en #rc3-world](https://matrix.to/#/!XxOXzjHtyrYRfFPsjx:hackint.org/$KE-6L46MKYXe7xTt6a4EIXz1d0s_QP3axwHqHjLiOZg?via=hackint.org&via=matrix.org)